### PR TITLE
init changes to include artifactory openmetrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,7 @@ Supported optional metrics:
 * `artifacts` - Extracts number of artifacts created/downloaded for each repository. Enabling this will add `artifactory_artifacts_*` metrics. Please note that on large Artifactory instances, this may impact the performance.
 * `replication_status` - Extracts status of replication for each repository which has replication enabled. Enabling this will add the `status` label to `artifactory_replication_enabled` metric.
 * `federation_status` - Extracts federation metrics. Enabling this will add two new metrics: `artifactory_federation_mirror_lag`, and `artifactory_federation_unavailable_mirror`. Please note that these metrics are only available in Artifactory Enterprise Plus and version 7.18.3 and above.
+* `open_metrics` - Exposes Open Metrics from the JFrog Platform. For more information about Open Metrics, please refer to [JFrog Platform Open Metrics](https://jfrog.com/help/r/jfrog-platform-administration-documentation/open-metrics).
 
 ### Grafana Dashboard
 

--- a/artifactory/openmetrics.go
+++ b/artifactory/openmetrics.go
@@ -1,0 +1,30 @@
+package artifactory
+
+import (
+	"github.com/go-kit/log/level"
+)
+
+const openMetricsEndpoint = "v1/metrics"
+
+type OpenMetrics struct {
+	Metric string
+	NodeId string
+}
+
+// FetchReplications makes the API call to replication endpoint and returns []Replication
+func (c *Client) FetchOpenMetrics() (OpenMetrics, error) {
+	var openMetrics OpenMetrics
+	level.Debug(c.logger).Log("msg", "Fetching openMetrics")
+	resp, err := c.FetchHTTP(openMetricsEndpoint)
+	if err != nil {
+		if err.(*APIError).status == 404 {
+			return openMetrics, nil
+		}
+		return openMetrics, err
+	}
+	openMetrics.NodeId = resp.NodeId
+	openMetrics.Metric = string(resp.Body)
+	level.Debug(c.logger).Log("msg", "OpenMetrics from Artifactory", "body", string(resp.Body))
+
+	return openMetrics, nil
+}

--- a/artifactory/openmetrics.go
+++ b/artifactory/openmetrics.go
@@ -7,11 +7,11 @@ import (
 const openMetricsEndpoint = "v1/metrics"
 
 type OpenMetrics struct {
-	Metric string
-	NodeId string
+	PromMetrics string
+	NodeId      string
 }
 
-// FetchReplications makes the API call to replication endpoint and returns []Replication
+// FetchOpenMetrics makes the API call to open metrics endpoint and returns all the open metrics
 func (c *Client) FetchOpenMetrics() (OpenMetrics, error) {
 	var openMetrics OpenMetrics
 	level.Debug(c.logger).Log("msg", "Fetching openMetrics")
@@ -22,9 +22,11 @@ func (c *Client) FetchOpenMetrics() (OpenMetrics, error) {
 		}
 		return openMetrics, err
 	}
-	openMetrics.NodeId = resp.NodeId
-	openMetrics.Metric = string(resp.Body)
+
 	level.Debug(c.logger).Log("msg", "OpenMetrics from Artifactory", "body", string(resp.Body))
+
+	openMetrics.NodeId = resp.NodeId
+	openMetrics.PromMetrics = string(resp.Body)
 
 	return openMetrics, nil
 }

--- a/collector/artifacts.go
+++ b/collector/artifacts.go
@@ -3,7 +3,6 @@ package collector
 import (
 	"encoding/json"
 	"fmt"
-
 	"github.com/go-kit/log/level"
 	"github.com/prometheus/client_golang/prometheus"
 )

--- a/collector/collector.go
+++ b/collector/collector.go
@@ -2,7 +2,6 @@ package collector
 
 import (
 	"strings"
-
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/version"
 )

--- a/collector/collector.go
+++ b/collector/collector.go
@@ -2,6 +2,7 @@ package collector
 
 import (
 	"strings"
+
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/version"
 )
@@ -68,7 +69,7 @@ var (
 		"unavailableMirror": newMetric("unavailable_mirror", "federation", "Unsynchronized federated mirror status", append([]string{"status"}, federationLabelNames...)),
 	}
 	openMetrics = metrics{
-		"openMetrics": newMetric("open_metrics", "openmetrics", "OpenMetrics proxied from Artifactory", append([]string{"metrics"}, defaultLabelNames...)),
+		"openMetrics": newMetric("open_metrics", "openmetrics", "OpenMetrics proxied from JFrog Platform", defaultLabelNames),
 	}
 )
 

--- a/collector/openMetrics.go
+++ b/collector/openMetrics.go
@@ -1,0 +1,58 @@
+package collector
+
+import (
+	"strings"
+
+	"github.com/go-kit/log/level"
+	"github.com/prometheus/client_golang/prometheus"
+	io_prometheus_client "github.com/prometheus/client_model/go"
+	"github.com/prometheus/common/expfmt"
+)
+
+func (e *Exporter) exportOpenMetrics(ch chan<- prometheus.Metric) error {
+	// Fetch Open Metrics
+	openMetrics, err := e.client.FetchOpenMetrics()
+	if err != nil {
+		level.Error(e.logger).Log("msg", "There was an issue when try to fetch openMetrics")
+		e.totalAPIErrors.Inc()
+		return err
+	}
+
+	level.Debug(e.logger).Log("msg", "OpenMetrics from Artifactory util", "body", openMetrics.Metric)
+
+	// assign openMetrics.Metric to a string variable
+	openMetricsString := openMetrics.Metric
+
+	parser := expfmt.TextParser{}
+	metrics, err := parser.TextToMetricFamilies(strings.NewReader(openMetricsString))
+	if err != nil {
+		// handle the error
+		return err
+	}
+
+	for _, family := range metrics {
+		for _, metric := range family.Metric {
+			// create a new metric descriptor
+			desc := prometheus.NewDesc(
+				prometheus.BuildFQName("remote", "openmetric", family.GetName()),
+				family.GetHelp(),
+				nil,
+				nil,
+			)
+
+			// create a new metric and collect it
+			switch family.GetType() {
+			case io_prometheus_client.MetricType_COUNTER:
+				ch <- prometheus.MustNewConstMetric(desc, prometheus.CounterValue, metric.GetCounter().GetValue())
+			case io_prometheus_client.MetricType_GAUGE:
+				ch <- prometheus.MustNewConstMetric(desc, prometheus.GaugeValue, metric.GetGauge().GetValue())
+				// case textparse.MetricTypeHistogram:
+				// 	// handle histograms
+				// case textparse.MetricTypeSummary:
+				// 	// handle summaries
+			}
+		}
+	}
+
+	return nil
+}

--- a/collector/openMetrics.go
+++ b/collector/openMetrics.go
@@ -32,11 +32,18 @@ func (e *Exporter) exportOpenMetrics(ch chan<- prometheus.Metric) error {
 
 	for _, family := range metrics {
 		for _, metric := range family.Metric {
+			// create labels map
+			labels := make(map[string]string)
+			for _, label := range metric.Label {
+				labels[*label.Name] = *label.Value
+			}
+
 			// create a new descriptor
 			desc := prometheus.NewDesc(
-				prometheus.BuildFQName("jfrog", "openmetrics", *family.Name),
+				family.GetName(),
 				family.GetHelp(),
-				nil, nil,
+				nil,
+				labels,
 			)
 
 			// create a new metric and collect it

--- a/config/config.go
+++ b/config/config.go
@@ -37,7 +37,7 @@ type OptionalMetrics struct {
 	Artifacts         bool
 	ReplicationStatus bool
 	FederationStatus  bool
-	OpenMetrics	      bool
+	OpenMetrics				bool
 }
 
 // Config represents all configuration options for running the Exporter.

--- a/config/config.go
+++ b/config/config.go
@@ -37,7 +37,7 @@ type OptionalMetrics struct {
 	Artifacts         bool
 	ReplicationStatus bool
 	FederationStatus  bool
-	OpenMetrics				bool
+	OpenMetrics        bool
 }
 
 // Config represents all configuration options for running the Exporter.

--- a/config/config.go
+++ b/config/config.go
@@ -22,7 +22,7 @@ var (
 	optionalMetrics = kingpin.Flag("optional-metric", "optional metric to be enabled. Pass multiple times to enable multiple optional metrics.").PlaceHolder("metric-name").Strings()
 )
 
-var optionalMetricsList = []string{"artifacts", "replication_status", "federation_status"}
+var optionalMetricsList = []string{"artifacts", "replication_status", "federation_status", "open_metrics"}
 
 // Credentials represents Username and Password or API Key for
 // Artifactory Authentication
@@ -37,6 +37,7 @@ type OptionalMetrics struct {
 	Artifacts         bool
 	ReplicationStatus bool
 	FederationStatus  bool
+	OpenMetrics			 bool
 }
 
 // Config represents all configuration options for running the Exporter.
@@ -88,6 +89,8 @@ func NewConfig() (*Config, error) {
 			optMetrics.ReplicationStatus = true
 		case "federation_status":
 			optMetrics.FederationStatus = true
+		case "open_metrics":
+			optMetrics.OpenMetrics = true
 		default:
 			return nil, fmt.Errorf("unknown optional metric: %s. Valid optional metrics are: %s", metric, optionalMetricsList)
 		}

--- a/config/config.go
+++ b/config/config.go
@@ -37,7 +37,7 @@ type OptionalMetrics struct {
 	Artifacts         bool
 	ReplicationStatus bool
 	FederationStatus  bool
-	OpenMetrics			 bool
+	OpenMetrics	      bool
 }
 
 // Config represents all configuration options for running the Exporter.


### PR DESCRIPTION
Enables this exporter to proxy Open Metrics from Jfrog Platform services

Cmd to run locally
```
go build -o exporter && . ./.env && ./exporter --optional-metric=open_metrics
```